### PR TITLE
fix: hash landing page feature images to prevent 404s

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -109,6 +109,11 @@ export default defineConfig({
       for (const element of gallery) {
         element.src = generateHashedImageName(ctx, element.src);
       }
+      const features = frontmatter.features;
+      for (const feature of features) {
+        if (feature.image)
+          feature.image = generateHashedImageName(ctx, feature.image);
+      }
       frontmatter.hero.image.src = generateHashedImageName(ctx, frontmatter.hero.image.src);
     }
     createNewsRedirect(page, ctx.siteConfig.outDir);


### PR DESCRIPTION
## Summary
- Landing page `features[].image` entries referenced raw `/img/help/1.6/*.webp` paths that aren't copied into the build output, causing four 404s on the live site.
- `transformPageData` already hashed `hero.image.src` and `gallery[].src`; this extends the same treatment to `features[].image` so the files are emitted under `/assets/` with content hashes.

## Test plan
- [x] `NODE_ENV=production pnpm vitepress build` succeeds
- [x] Hashed files present in `dist/assets/` for `01_player_dark`, `06_rating`, `09_now_playing`, `13_library_albums_grid`
- [x] `dist/index.html` no longer contains any `/img/help/1.6/` references