### PR TITLE
feat: add v1.6.0-rc.2 news post and update announcement bar

### DIFF
--- a/.vitepress/theme/Landing.vue
+++ b/.vitepress/theme/Landing.vue
@@ -11,9 +11,9 @@ const { frontmatter } = useData();
 
 <template>
   <div class="announcement-bar">
-    <a href="/news/2026-04-03-v1-6-0-preview">
+    <a href="/news/2026-04-18-v1-6-0-rc-2">
       <span class="announcement-badge">New</span>
-      v1.6.0 coming soon <span class="announcement-arrow">&rarr;</span>
+      v1.6.0-rc.2 available for testing <span class="announcement-arrow">&rarr;</span>
     </a>
   </div>
   <LandingHero :hero="frontmatter.hero" />

--- a/news/2026-04-18-v1-6-0-rc-2.md
+++ b/news/2026-04-18-v1-6-0-rc-2.md
@@ -1,0 +1,48 @@
+---
+layout: news-item
+title: "v1.6.0-rc.2 is out for testing"
+subtitle: Release candidates on GitHub while the Play Store beta waits on approvals
+date: 2026-04-18 19:00:00
+author: "Konstantinos Paparas"
+gravatar: '81cf01a2e33f4bfbddb37f43818841e0'
+bsky: "kelsos.bsky.social"
+categories: [news, release]
+---
+
+v1.6.0 is now in release-candidate territory. rc.1 went up a couple of days ago, and rc.2 is out today. If you want to help shake out the last issues before v1.6.0 ships, this is the moment.
+
+---
+
+## Where to get it
+
+Both release candidates are published on [GitHub Releases](https://github.com/musicbeeremote/mbrc/releases) as pre-releases. Grab the APK and sideload it. The plugin you already have works with it, no plugin update needed.
+
+Two APK variants are published:
+
+- **GitHub** flavor, with no Crashlytics and no Firebase. This is the one most people will want.
+- **Play** flavor, with Crashlytics. This is the build that will eventually go to the Play Store.
+
+## What's in rc.1
+
+rc.1 is the first cut of everything covered in the [v1.6.0 preview post](/news/2026-04-03-v1-6-0-preview): the Material 3 and Compose rewrite, the improved library browsing with sorting and album grid view, playlist folder navigation, half-star ratings, Last.fm love and ban from the player, auto-reconnect, the rebuilt widget, the new track details view, and the long-standing issues that finally got closed. The [full rc.1 changelog](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.0-rc.1) on GitHub lists every PR that went in.
+
+## What changed in rc.2
+
+rc.2 is a small follow-up. The Play flavor in rc.1 was broken: the CI job was missing its Firebase configuration and produced an APK that crashes on launch. If you grabbed the Play APK from rc.1, please switch to rc.2. The GitHub flavor from rc.1 was unaffected.
+
+The [rc.2 changelog](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.0-rc.2) is short: the CI pipeline now fails loudly when `google-services.json` is missing on a tag build, plus the version bump.
+
+## About the Play Store
+
+The plan is still to put the open beta on the Play Store's testing channel before promoting to production. That part is waiting on Google. The app needs approval for a few permissions under the current Play policies, and that review is in progress. Until it clears, GitHub Releases is the only place to get builds.
+
+As soon as the Play Store beta is live I'll post an update here. If the feedback on GitHub is clean, the production release follows shortly after and MusicBee Remote is back on the Play Store.
+
+## How to help
+
+If you try an rc build, I'd love to hear what breaks (or doesn't):
+
+- File an issue on [GitHub](https://github.com/musicbeeremote/mbrc/issues) for crashes, connection weirdness, library glitches, widget oddities, anything.
+- Drop by [Discord](https://discord.gg/rceTb57) if you want to chat or ask before filing.
+
+Thanks for testing. The closer rc.2 is to working for everyone, the sooner v1.6.0 can go out.


### PR DESCRIPTION
## Summary
- New news post `news/2026-04-18-v1-6-0-rc-2.md` announcing v1.6.0-rc.1 and rc.2 on GitHub Releases, linking back to the v1.6.0 preview for the full feature list.
- Covers the rc.1 → rc.2 delta (Play flavor CI Firebase config fix) and the Play Store open-beta status (pending Google permission approvals).
- Updates the landing-page announcement bar to point at the new post.

## Test plan
- [x] `NODE_ENV=production pnpm vitepress build` succeeds
- [ ] Spot-check the rendered post and announcement link in preview