### PR TITLE
feat: add Google Play link and document open testing

### DIFF
--- a/.vitepress/theme/LandingDownload.vue
+++ b/.vitepress/theme/LandingDownload.vue
@@ -58,14 +58,26 @@ const pluginZip = computed(() =>
             <span class="download-date">{{ releases.app.date }}</span>
           </div>
           <div class="download-actions">
-            <a
-              v-if="appApk"
-              class="download-button"
-              :href="appApk.url"
-            >
-              Download APK
-              <span class="download-size">({{ formatSize(appApk.size) }})</span>
-            </a>
+            <div class="download-buttons-row">
+              <a
+                v-if="appApk"
+                class="download-button"
+                :href="appApk.url"
+              >
+                Download APK
+                <span class="download-size">({{ formatSize(appApk.size) }})</span>
+              </a>
+              <a
+                class="download-play-badge"
+                href="https://play.google.com/store/apps/details?id=com.kelsos.mbrc"
+                aria-label="Get it on Google Play"
+              >
+                <img
+                  src="/img/google-play-badge.svg"
+                  alt="Get it on Google Play"
+                >
+              </a>
+            </div>
             <div class="download-links">
               <a
                 class="download-fallback"
@@ -143,7 +155,7 @@ const pluginZip = computed(() =>
 }
 
 .download-container {
-  max-width: 800px;
+  max-width: 960px;
   margin: 0 auto;
   text-align: center;
 }
@@ -222,6 +234,14 @@ const pluginZip = computed(() =>
 
 .download-actions {
   display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.download-buttons-row {
+  display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   justify-content: center;
@@ -249,6 +269,22 @@ const pluginZip = computed(() =>
 .download-size {
   font-weight: 400;
   opacity: 0.8;
+}
+
+.download-play-badge {
+  display: inline-flex;
+  align-items: center;
+  transition: transform 0.2s ease;
+}
+
+.download-play-badge img {
+  height: 40px;
+  width: auto;
+  display: block;
+}
+
+.download-play-badge:hover {
+  transform: translateY(-1px);
 }
 
 .download-fallback {

--- a/.vitepress/theme/LandingDownload.vue
+++ b/.vitepress/theme/LandingDownload.vue
@@ -75,7 +75,7 @@ const pluginZip = computed(() =>
                 <img
                   src="/img/google-play-badge.svg"
                   alt="Get it on Google Play"
-                >
+                />
               </a>
             </div>
             <div class="download-links">

--- a/.vitepress/theme/LandingHero.vue
+++ b/.vitepress/theme/LandingHero.vue
@@ -53,7 +53,7 @@ defineProps<LandingHeroProps>();
               <img
                 src="/img/google-play-badge.svg"
                 alt="Get it on Google Play"
-              >
+              />
             </a>
             <a
               v-else

--- a/.vitepress/theme/LandingHero.vue
+++ b/.vitepress/theme/LandingHero.vue
@@ -40,15 +40,30 @@ defineProps<LandingHeroProps>();
           {{ hero.tagline }}
         </p>
         <div class="hero-actions">
-          <a
+          <template
             v-for="(button, index) in hero.actions"
             :key="button.link"
-            class="hero-button"
-            :class="index === 0 ? 'hero-button-primary' : 'hero-button-secondary'"
-            :href="button.link"
           >
-            {{ button.text }}
-          </a>
+            <a
+              v-if="button.link.includes('play.google.com')"
+              class="hero-play-badge"
+              :href="button.link"
+              :aria-label="button.text"
+            >
+              <img
+                src="/img/google-play-badge.svg"
+                alt="Get it on Google Play"
+              >
+            </a>
+            <a
+              v-else
+              class="hero-button"
+              :class="index === 0 ? 'hero-button-primary' : 'hero-button-secondary'"
+              :href="button.link"
+            >
+              {{ button.text }}
+            </a>
+          </template>
         </div>
       </div>
       <div class="hero-image-wrapper">
@@ -116,6 +131,23 @@ defineProps<LandingHeroProps>();
   display: flex;
   gap: 1rem;
   flex-wrap: wrap;
+  align-items: center;
+}
+
+.hero-play-badge {
+  display: inline-flex;
+  align-items: center;
+  transition: transform 0.2s ease;
+}
+
+.hero-play-badge img {
+  height: 52px;
+  width: auto;
+  display: block;
+}
+
+.hero-play-badge:hover {
+  transform: translateY(-1px);
 }
 
 .hero-button {

--- a/help/1.6/getting-started.md
+++ b/help/1.6/getting-started.md
@@ -14,7 +14,17 @@ next:
 
 There are two ways to install the application:
 
-### GitHub Release (recommended)
+### Google Play Store (open testing)
+
+MusicBee Remote is currently available through the **open testing** channel on Google Play. Anyone with the link can join — no invitation is required.
+
+1. Open the [MusicBee Remote listing on Google Play](https://play.google.com/store/apps/details?id=com.kelsos.mbrc) on your Android device.
+2. Scroll to the **Join the beta** section and tap **Join**. It can take a few minutes for your account to be enrolled.
+3. Once enrolled, install or update the app from the same page. Future updates arrive automatically through Play.
+
+To leave the beta, return to the listing and tap **Leave** under the beta section. You will then be moved back to the stable track once v1.6.0 is promoted to production.
+
+### GitHub Release
 
 Download the latest APK from the [GitHub Releases](https://github.com/musicbeeremote/mbrc/releases/latest) page. Two variants are available:
 
@@ -22,10 +32,6 @@ Download the latest APK from the [GitHub Releases](https://github.com/musicbeere
 - **Play release** — Includes Firebase Crashlytics for crash tracking
 
 To install, download the APK on your device and enable installation from unknown sources if prompted.
-
-### Google Play Store
-
-The application will be available on the Google Play Store soon. Check the [website](https://mbrc.kelsos.net) for updates.
 
 ## Connection
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,9 @@ hero:
   text: "for Android"
   tagline: "Control MusicBee from your Android device. Browse your library, manage playlists, and enjoy your music — from anywhere in your home."
   actions:
-    - text: Download App
+    - text: Get it on Google Play
+      link: https://play.google.com/store/apps/details?id=com.kelsos.mbrc
+    - text: Download APK
       link: https://github.com/musicbeeremote/mbrc/releases/latest
     - text: Download Plugin
       link: https://github.com/musicbeeremote/mbrc-plugin/releases/latest


### PR DESCRIPTION
## Summary
- Add the official Google Play badge to the hero actions and the Android app download card on the landing page
- Widen the download container so the APK button and Play badge sit on the same row, with "All releases →" underneath
- Replace the stale "coming soon" note in `help/1.6/getting-started.md` with proper instructions for joining the Google Play open testing channel

## Test plan
- [ ] `pnpm docs:dev` — verify hero shows the Play badge alongside the APK/Plugin buttons
- [ ] Scroll to **Get Started** — verify APK + Play badge render on the same row, "All releases →" wraps below
- [ ] Open `/help/1.6/getting-started` — verify the Play Store / open testing section renders correctly