### PR TITLE
docs: add v1.6.0-rc.4 news post

### DIFF
--- a/news/2026-04-22-v1-6-0-rc-4.md
+++ b/news/2026-04-22-v1-6-0-rc-4.md
@@ -1,0 +1,41 @@
+---
+layout: news-item
+title: "v1.6.0-rc.4 with more crash fixes"
+subtitle: Another round of stability fixes from beta feedback, with a staged production rollout planned for May
+date: 2026-04-22 17:00:00
+author: "Konstantinos Paparas"
+gravatar: '81cf01a2e33f4bfbddb37f43818841e0'
+bsky: "kelsos.bsky.social"
+categories: [news, release]
+---
+
+rc.4 is out on [GitHub Releases](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.0-rc.4) and heading to the Play Store testing channel. This one closes out several more crashes that surfaced on rc.3.
+
+---
+
+## What changed in rc.4
+
+Three crash fixes, plus a couple of small cleanups:
+
+- No more crash on the now-playing track when the year field is missing.
+- The widget opens the app reliably again (switched to `actionStartActivity`).
+- Broadcast actions that throw no longer take the app down with them.
+- Dependency updates and a fix for the App License screen.
+
+No feature changes, no behavior changes. The full list is in the [rc.4 changelog](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.0-rc.4).
+
+If you're on rc.3, please update. Crash reports from the Play flavor and issues filed on GitHub were what drove this round, so thanks to everyone who sent them in.
+
+## What's next
+
+The plan from here is to keep monitoring rc.4 and gathering feedback for a few more days. Once things look quiet across both the GitHub and Play builds, v1.6.0 moves into a **staged rollout on the Play Store starting in May**. That means a small percentage of production users first, watching crash metrics, and ramping up from there rather than flipping the full release at once.
+
+If a new crash shows up during the staged rollout, the rollout pauses and another rc ships before continuing.
+
+## How to help
+
+- Crashes and odd behavior go on [GitHub issues](https://github.com/musicbeeremote/mbrc/issues).
+- [Discord](https://discord.gg/rceTb57) is open for questions and quicker back-and-forth.
+- If you're on the [Play Store beta](https://play.google.com/store/apps/details?id=com.kelsos.mbrc), just keeping the app installed and using it helps — Crashlytics reports from the Play flavor are what's driving these fixes.
+
+Almost there. Thanks again for testing.


### PR DESCRIPTION
## Summary
- Add news post for v1.6.0-rc.4, covering the additional crash fixes (missing year field, widget open, broadcast action throw) plus the App License screen / deps cleanup.
- Announces the plan to keep monitoring rc feedback and begin a staged Play Store production rollout in May.

## Test plan
- [ ] `pnpm docs:build` succeeds
- [ ] Post renders correctly and appears on the news index
- [ ] Announcement bar on the landing page picks up the new post