### PR TITLE
docs: announce v1.6.0 final release

### DIFF
--- a/news/2026-06-01-v1-6-0-released.md
+++ b/news/2026-06-01-v1-6-0-released.md
@@ -1,0 +1,57 @@
+---
+layout: news-item
+title: "MusicBee Remote v1.6.0 is here"
+subtitle: A full rebuild on a modern Android stack, and back on the Play Store
+date: 2026-06-01 19:00:00
+author: "Konstantinos Paparas"
+gravatar: '81cf01a2e33f4bfbddb37f43818841e0'
+bsky: "kelsos.bsky.social"
+categories: [news, release]
+---
+
+v1.6.0 is out. After a long run of release candidates, the [final build](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.0) is published, and MusicBee Remote is listed on the Play Store again after a spell unlisted. For now v1.6.0 is on the open testing channel, with the staged production rollout planned for next week.
+
+---
+
+## The long way here
+
+This release closes out a modernization effort that's been going since around 2017. The point was never any single feature. It was getting the whole app onto a current Android stack so it could move forward again. That meant rewriting nearly every screen, replacing a pile of legacy libraries, and rebuilding the parts that had aged badly. v1.6.0 is where that work comes together.
+
+If you've used MusicBee Remote before, it won't feel like the same app.
+
+## What's new in v1.6.0
+
+**A new interface.** The UI was rebuilt with Jetpack Compose and Material 3, replacing the old XML layouts. It's faster, the animations are smoother, and it follows your system dark or light theme. Tablets get a proper layout instead of a stretched phone screen.
+
+**Better library browsing.** Sort genres, artists, albums, and tracks by name or artist. Switch to an album grid view when you'd rather browse visually. Drill down from genre to artist to album, and jump straight to an album or artist from the player or the queue. Playlists support folder navigation, and non-album tracks are grouped sensibly instead of scattered. There's a shuffle and play-all action for the library too.
+
+**Ratings and Last.fm.** Half-star ratings are in, you can love or ban tracks on Last.fm from the player, and a new track details view shows the full metadata.
+
+**More reliable connections.** This was the biggest pain point in the old app. v1.6.0 reconnects on its own when the link drops, shows a progress indicator while connecting, and stops cleanly when you disconnect on purpose. The offline state is clearer, and LAN discovery now finds every MusicBee host on the network in a single scan.
+
+**Widget, notifications, and sync.** The home-screen widget was rebuilt to be more reliable, notifications behave properly, and library sync runs in the background with visible progress.
+
+**Under the hood.** The app targets Android 16 (SDK 36), starts faster thanks to baseline profiles, and ships with much better test coverage. Smaller fixes landed on top, including marquee scrolling for long track titles, steadier now-playing queue paging and drag, and tighter memory use under heavy network load.
+
+A number of long-standing requests got closed along the way, some open since 2017. The [full v1.6.0 changelog](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.0) lists every PR that went in. No plugin update is required; v1.6.0 works with the MusicBee plugin you already have.
+
+## How the rollout works
+
+v1.6.0 is on the Play Store's open testing channel right now. The plan is to leave it there for a few days, and if nothing major surfaces, start the staged production rollout next week. It begins at around 10% of users and ramps up from there while I watch crash metrics. If a serious problem shows up mid-rollout, it pauses and a fix ships before it continues.
+
+The original target was May. A bug in the now-playing queue surfaced late and needed more work than expected, which pushed it into June. The queue is one of the parts you touch most, so the extra time was worth it.
+
+If you'd rather not wait on the staged rollout, you can install it today, and which build you pick is worth a thought. Install from the Play Store when it reaches you (or join the open testing channel now) if you want automatic updates; that build includes crash reporting through Crashlytics and Firebase. Grab the APK from [GitHub Releases](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.0) instead if you prefer privacy, since that build ships without Crashlytics or Firebase, though you'll need to update it by hand.
+
+## What's next
+
+With the app modernized, attention shifts to the plugin and the protocol between them. A few of the most-requested features aren't possible on the current protocol, so the next stretch of work is exploratory.
+
+- **A protocol update (v5).** Several features are blocked on new data and capabilities from the plugin, including sorting by year, date added, and rating ([#279](https://github.com/musicbeeremote/mbrc/issues/279)), synchronized lyrics, playlist editing from the app, queue duration, and stop-after-current. The plan is to drop backwards support for everything before the v4 API and standardize on a clean v5 schema instead of bolting more onto the old one.
+- **A Rust core for the plugin.** I'm exploring moving the core of the plugin to Rust, with the existing C# side calling into it. The work so far focuses on exact parity with the legacy behaviour by replaying real sessions against the new core. If it pans out, it makes room for a standardized WebSocket and HTTP API with an embedded web app, so MusicBee Remote doesn't have to stay Android-only.
+
+These are explorations, not commitments with dates attached, but that's the direction.
+
+## Thanks
+
+To everyone who tested the release candidates, filed crashes, and waited, in some cases for years: thank you. That feedback is what got v1.6.0 finished. If you hit something, [open an issue on GitHub](https://github.com/musicbeeremote/mbrc/issues) or come say hi on [Discord](https://discord.gg/rceTb57).


### PR DESCRIPTION
Announcement post for the v1.6.0 final release.

## What it covers
- **v1.6.0 is out** — links the [final release](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.0); the app is listed on the Play Store again after being unlisted.
- **The features** — Compose/Material 3 rewrite, library browsing/sorting/album-grid, half-star + Last.fm love/ban, resilient connections + LAN discovery, rebuilt widget/notifications/background sync, Android 16 + baseline profiles, plus final-build polish (marquee titles, queue paging/drag, OOM bounding).
- **Rollout** — open testing now, staged production rollout starting next week at ~10% and ramping; honest note about the May→June slip from a now-playing queue bug.
- **Build choice** — Play build for automatic updates (Crashlytics/Firebase) vs GitHub APK for privacy (no Crashlytics/Firebase, manual updates).
- **What's next** — v5 protocol (drop pre-v4 support, standardize the v5 schema, refs #279) and the Rust plugin-core exploration toward a standardized WebSocket/HTTP API with an embedded web app.

## Notes
- Facts cross-checked against the v1.6.0 changelog.
- Editorial pass to remove em dashes and reduce AI-tropey phrasing.

Builds clean; lands as the newest item in the news RSS feed.
