### PR TITLE
Add v1.6.1 release news post

### DIFF
--- a/news/2026-06-27-v1-6-1.md
+++ b/news/2026-06-27-v1-6-1.md
@@ -1,0 +1,37 @@
+---
+layout: news-item
+title: "MusicBee Remote v1.6.1 on the test channel"
+subtitle: A round of stability fixes while v1.6.0 keeps rolling out
+date: 2026-06-27 19:00:00
+author: "Konstantinos Paparas"
+gravatar: '81cf01a2e33f4bfbddb37f43818841e0'
+bsky: "kelsos.bsky.social"
+categories: [news, release]
+---
+
+v1.6.1 is out on the open testing channel. It's a small follow-up to [v1.6.0](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.0) with stability fixes rather than new features. In the meantime the v1.6.0 rollout on the Play Store keeps widening, and the goal is to fully replace the old v1.5.1 over the next few weeks.
+
+---
+
+## What changed
+
+Most of this release tightens up the now-playing and connection code that gets the heaviest use.
+
+- **Lower memory pressure.** Now-playing reconciliation and inbound socket reads are now bounded, so the app doesn't run out of memory under heavy network load.
+- **Steadier now-playing.** A single-flight refresh and proper handling of the `libraryplayall` broadcast keep the now-playing list consistent.
+- **No more duplicate-key crashes.** Keys are reconciled by position, which avoids the duplicate-key cases that could crash the list.
+- **Fresh widgets after updates.** The home-screen widget rebuilds itself when the app updates, so it no longer holds onto stale actions.
+- **Android 12+ foreground service fix.** Fixes a crash when `RemoteService` starts as a foreground service on Android 12 and later.
+- **Queue refresh progress.** A progress bar shows while the queue refreshes during sync.
+
+The [full v1.6.1 changelog](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.1) lists every PR. There's no plugin update needed; v1.6.1 works with the MusicBee plugin you already have.
+
+## Getting it
+
+v1.6.1 is on the open testing channel for now. If you want it without waiting, download the Play APK from [GitHub Releases](https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.1) and install it. It's the same build that's on the Play Store, so once the release reaches production the Play Store picks it up and keeps it updated for you from there.
+
+There's also a separate GitHub APK in the release if you'd rather avoid Crashlytics and Firebase. That one you update by hand.
+
+Alongside this, the v1.6.0 production rollout keeps ramping up, with the plan to retire v1.5.1 completely over the coming weeks.
+
+If you run into something, [open an issue on GitHub](https://github.com/musicbeeremote/mbrc/issues) or come say hi on [Discord](https://discord.gg/rceTb57).


### PR DESCRIPTION
Adds a news post for the v1.6.1 release.

## Summary
- v1.6.1 ships to the open testing channel with stability fixes (memory bounds, now-playing reconciliation, duplicate-key crash, widget refresh, Android 12+ FGS crash, queue refresh progress)
- Notes that the v1.6.0 production rollout keeps widening, aiming to retire v1.5.1 over the coming weeks
- Explains the Play APK can be sideloaded now and auto-updates via Play Store once it reaches production, since it's the same build

Release reference: https://github.com/musicbeeremote/mbrc/releases/tag/v1.6.1